### PR TITLE
Improve docs by removing confusion with AWS env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,6 @@ _Variables in bold are required._
 
 | Name                         | Default               | Description                                                                            |
 | ---------------------------- | --------------------- | -------------------------------------------------------------------------------------- |
-| AWS_ACCESS_KEY_ID            |                       | The AWS key ID. **This is also required as GitHub repository secret.**                 |
-| AWS_ACCOUNT_ID               |                       | The AWS account id. **This is only required as GitHub repository secret.**             |
-| AWS_ECR_REPOSITORY           |                       | The AWS ECR repository. **This is only required as GitHub repository secret.**         |
-| **AWS_REGION**               |                       | The AWS region. **This is also required as GitHub repository secret.**                 |
-| AWS_SECRET_ACCESS_KEY        |                       | The AWS access key. **This is also required as GitHub repository secret.**             |
 | **BITSWAP_PEER_MULTIADDR**   |                       | The multiaddr of the BitSwap peer to download the data from. Omit the `/p2p/...` part. |
 | ENV_FILE_PATH                | `$PWD/.env`           | The environment file to load.                                                          |
 | **HANDLER**                  |                       | The operation to execute. Can be `content` or `advertisement`.                         |
@@ -22,3 +17,5 @@ _Variables in bold are required._
 | PEER_ID_S3_BUCKET            |                       | The S3 bucket to download the BitSwap PeerID in JSON format.                           |
 | S3_BUCKET                    | `advertisements`      | The S3 bucket where to upload advertisement and head information to.                   |
 | SQS_ADVERTISEMENTS_QUEUE_URL | `advertisementsQueue` | The SQS topic URL to upload advertisement to for announcement.                         |
+
+Also check [AWS specific configuration](https://github.com/elastic-ipfs/elastic-ipfs/blob/main/aws.md).


### PR DESCRIPTION
Remove AWS specific env vars and link to AWS configuration doc. Also removing CICD specific environment variables. Current doc is generating confusion. Developers often think that is necessary to configure long living keys inside lambda and EC2