### PR TITLE
docs: add contribute and release process to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,15 @@ Also check [AWS specific configuration](https://github.com/elastic-ipfs/elastic-
 ## Issues
 
 Please report issues in the [elastic-ipfs/elastic-ipfs repo](https://github.com/elastic-ipfs/elastic-ipfs/issues).
+
+## Contribute and release process
+
+This is the process to contribute and get a new build deployed:
+
+- Create a Pull Request with the intended change
+- Get a review from one of the team members
+- Deploy the Pull Request branch into a dev build using Github Action `Dev | Build And Deploy` and selecting branch
+- Unit test Dev build lambdas [dev-ep-publishing-advertisement](https://us-west-2.console.aws.amazon.com/lambda/home?region=us-west-2#/functions/dev-ep-publishing-advertisement?tab=testing) and [dev-ep-publishing-content](https://us-west-2.console.aws.amazon.com/lambda/home?region=us-west-2#/functions/dev-ep-publishing-content?tab=testing) in AWS Console, with a given Event JSON. Validate lambda output and expected side effects.
+- Merge Pull Request after being approved
+- Staging release will be automatically created
+- Production release will need to be authorized by one of the admins of the repo.


### PR DESCRIPTION
Adds contribute and release process guidelines similarly to https://github.com/elastic-ipfs/indexer-lambda/pull/74

A couple of questions @simone-sanfratello @francardoso93 
- do you have a sample test JSON Event like we have for `indexer-lambda`?
- https://github.com/elastic-ipfs/bitswap-e2e-tests only tests e2e for bitswap peer and not related to this part of the system right?