### PR TITLE
fix!: advertise ipfs-gateway-http as http metadata codec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@ipld/dag-cbor": "^7.0.3",
         "@ipld/dag-json": "^8.0.11",
         "@libp2p/peer-id-factory": "^2.0.3",
-        "@web3-storage/ipni": "^1.1.0",
+        "@web3-storage/ipni": "^2.0.0",
         "bl": "^5.0.0",
         "dotenv": "^10.0.0",
         "hdr-histogram-js": "^3.0.0",
@@ -36,7 +36,8 @@
         "eslint-plugin-promise": "^5.1.1",
         "pino-pretty": "^7.5.1",
         "prettier": "^2.4.1",
-        "tap": "^15.1.6"
+        "tap": "^15.1.6",
+        "varint": "^6.0.0"
       },
       "engines": {
         "node": ">=14.15.0"
@@ -2414,9 +2415,9 @@
       }
     },
     "node_modules/@web3-storage/ipni": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@web3-storage/ipni/-/ipni-1.1.0.tgz",
-      "integrity": "sha512-0+R+LI3JUgxWhxT7CJScBX2a/wssnn7NKqO94o2MncQROHI7ei4kBf0xZRB+tOpqWF8DbvOmd+FnWgfmrMHZiQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/ipni/-/ipni-2.0.0.tgz",
+      "integrity": "sha512-4Y0cq8YlYqBqFMCpLbXWoR7wec4AqYEZ15Suh3mqGWjVeV6jIkYx2vtN+b14aNmYBmvUBS9jGyUXv4t3SkD/+w==",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.0",
         "@ipld/dag-json": "^10.0.1",
@@ -10747,9 +10748,9 @@
       }
     },
     "@web3-storage/ipni": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@web3-storage/ipni/-/ipni-1.1.0.tgz",
-      "integrity": "sha512-0+R+LI3JUgxWhxT7CJScBX2a/wssnn7NKqO94o2MncQROHI7ei4kBf0xZRB+tOpqWF8DbvOmd+FnWgfmrMHZiQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/ipni/-/ipni-2.0.0.tgz",
+      "integrity": "sha512-4Y0cq8YlYqBqFMCpLbXWoR7wec4AqYEZ15Suh3mqGWjVeV6jIkYx2vtN+b14aNmYBmvUBS9jGyUXv4t3SkD/+w==",
       "requires": {
         "@ipld/dag-cbor": "^9.0.0",
         "@ipld/dag-json": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@ipld/dag-cbor": "^7.0.3",
     "@ipld/dag-json": "^8.0.11",
     "@libp2p/peer-id-factory": "^2.0.3",
-    "@web3-storage/ipni": "^1.1.0",
+    "@web3-storage/ipni": "^2.0.0",
     "bl": "^5.0.0",
     "dotenv": "^10.0.0",
     "hdr-histogram-js": "^3.0.0",
@@ -44,7 +44,8 @@
     "eslint-plugin-promise": "^5.1.1",
     "pino-pretty": "^7.5.1",
     "prettier": "^2.4.1",
-    "tap": "^15.1.6"
+    "tap": "^15.1.6",
+    "varint": "^6.0.0"
   },
   "engines": {
     "node": ">=14.15.0"

--- a/test/advertisement.test.js
+++ b/test/advertisement.test.js
@@ -3,6 +3,7 @@
 process.env.HANDLER = 'advertisement'
 
 const t = require('tap')
+const varint = require('varint')
 const dagJson = require('@ipld/dag-json')
 const { MockAgent, setGlobalDispatcher } = require('undici')
 const { awsRegion, s3Bucket, indexerNodeUrl } = require('../src/config')
@@ -97,7 +98,7 @@ t.test('advertisement - links to the previous head and notifies the indexer', as
 })
 
 t.test('advertisement - extended provider', async t => {
-  t.plan(10)
+  t.plan(11)
 
   const mockAgent = new MockAgent()
   const mockHeadPool = mockAgent.get(`https://${s3Bucket}.s3.${awsRegion}.amazonaws.com`)
@@ -142,6 +143,7 @@ t.test('advertisement - extended provider', async t => {
   t.equal(ad.PreviousID.toString(), head)
   t.equal(ad.ExtendedProvider.Providers.length, 2)
   t.equal(ad.ExtendedProvider.Providers[1].Addresses[0], '/dns4/freeway.dag.house/tcp/443/https' )
+  t.same(ad.ExtendedProvider.Providers[1].Metadata, new Uint8Array(varint.encode(0x0920)))
 })
 
 t.test('advertisement - handles head fetching HTTP error', async t => {


### PR DESCRIPTION
When announcing our http endpoint use the `0x920` as the metadata prefix for that provider to denote `HTTP IPFS Gateway trustless datatransfer`, that Lassie use to infer it can fetch verifiable block data in CARs over http from that endpoint.

see: https://github.com/web3-storage/ipni/pull/13

License: MIT