### PR TITLE
fix: add missing http payload length

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@ipld/dag-cbor": "^7.0.3",
         "@ipld/dag-json": "^8.0.11",
         "@libp2p/peer-id-factory": "^2.0.3",
-        "@web3-storage/ipni": "^2.0.0",
+        "@web3-storage/ipni": "^3.0.0",
         "bl": "^5.0.0",
         "dotenv": "^10.0.0",
         "hdr-histogram-js": "^3.0.0",
@@ -2415,9 +2415,9 @@
       }
     },
     "node_modules/@web3-storage/ipni": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@web3-storage/ipni/-/ipni-2.0.0.tgz",
-      "integrity": "sha512-4Y0cq8YlYqBqFMCpLbXWoR7wec4AqYEZ15Suh3mqGWjVeV6jIkYx2vtN+b14aNmYBmvUBS9jGyUXv4t3SkD/+w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/ipni/-/ipni-3.0.0.tgz",
+      "integrity": "sha512-wK1dgj09GPWqf23573tHzuv/Lx79wwTfvf7Q1NoGDXueBf4AH/ScS9eamsxRtKwtHViNkW0lhl9APr3pLTIQ+w==",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.0",
         "@ipld/dag-json": "^10.0.1",
@@ -10748,9 +10748,9 @@
       }
     },
     "@web3-storage/ipni": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@web3-storage/ipni/-/ipni-2.0.0.tgz",
-      "integrity": "sha512-4Y0cq8YlYqBqFMCpLbXWoR7wec4AqYEZ15Suh3mqGWjVeV6jIkYx2vtN+b14aNmYBmvUBS9jGyUXv4t3SkD/+w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/ipni/-/ipni-3.0.0.tgz",
+      "integrity": "sha512-wK1dgj09GPWqf23573tHzuv/Lx79wwTfvf7Q1NoGDXueBf4AH/ScS9eamsxRtKwtHViNkW0lhl9APr3pLTIQ+w==",
       "requires": {
         "@ipld/dag-cbor": "^9.0.0",
         "@ipld/dag-json": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@ipld/dag-cbor": "^7.0.3",
     "@ipld/dag-json": "^8.0.11",
     "@libp2p/peer-id-factory": "^2.0.3",
-    "@web3-storage/ipni": "^2.0.0",
+    "@web3-storage/ipni": "^3.0.0",
     "bl": "^5.0.0",
     "dotenv": "^10.0.0",
     "hdr-histogram-js": "^3.0.0",

--- a/test/advertisement.test.js
+++ b/test/advertisement.test.js
@@ -143,7 +143,9 @@ t.test('advertisement - extended provider', async t => {
   t.equal(ad.PreviousID.toString(), head)
   t.equal(ad.ExtendedProvider.Providers.length, 2)
   t.equal(ad.ExtendedProvider.Providers[1].Addresses[0], '/dns4/freeway.dag.house/tcp/443/https' )
-  t.same(ad.ExtendedProvider.Providers[1].Metadata, new Uint8Array(varint.encode(0x0920)))
+  // the last byte is a varint 0 denoting the empty payload length see: https://github.com/web3-storage/ipni/pull/15
+  const httpMetaWith0lengthpayload = varint.encode(0x0920, new Uint8Array(3)) // [ 160, 18, 0 ]
+  t.same(ad.ExtendedProvider.Providers[1].Metadata, httpMetaWith0lengthpayload)
 })
 
 t.test('advertisement - handles head fetching HTTP error', async t => {


### PR DESCRIPTION
the http metadata should have a payload length... of zero

see: ttps://github.com/web3-storage/ipni/pull/15

License: MIT