### PR TITLE
feat: clear extended provider via ClearExtendedProvider special message

### DIFF
--- a/src/handlers/advertisement.js
+++ b/src/handlers/advertisement.js
@@ -18,6 +18,9 @@ const telemetry = require('../telemetry')
 // see: https://github.com/elastic-ipfs/publisher-lambda/pull/27
 const SPECIAL_MESSAGE_ANNOUNCE_HTTP_PROVIDER = 'AnnounceHTTP'
 
+// see: https://github.com/ipni/storetheindex/pull/2814
+const SPECIAL_MESSAGE_CLEAR_EXTENDED_PROVIDER = 'ClearExtendedProvider'
+
 async function fetchHeadCid() {
   try {
     telemetry.increaseCount('http-head-cid-fetchs')
@@ -147,6 +150,7 @@ async function main(event) {
 
     for (const record of event.Records) {
       let ad
+      let clearExtendedProvider = false
 
       if (record.body === SPECIAL_MESSAGE_ANNOUNCE_HTTP_PROVIDER) {
         const http = new Provider({
@@ -158,6 +162,14 @@ async function main(event) {
           previous: headCid,
           providers: [bits, http]
         })
+      } else if (record.body === SPECIAL_MESSAGE_CLEAR_EXTENDED_PROVIDER) {
+        ad = new Advertisement({
+          previous: headCid,
+          providers: [bits],
+          entries: null,
+          context: null
+        })
+        clearExtendedProvider = true
       } else {
         const entries = CID.parse(record.body)
         const context = Buffer.from(entries.toString())
@@ -170,6 +182,14 @@ async function main(event) {
       }
 
       const value = await ad.encodeAndSign()
+      // The library only writes ExtendedProvider when providers.length > 1; attach
+      // the empty-Providers shape after signing so storetheindex's Empty() clearing
+      // path triggers (https://github.com/ipni/storetheindex/pull/2814). The AD
+      // signature covers previous+entries+provider+addresses+metadata+IsRm only,
+      // so this attachment does not invalidate it.
+      if (clearExtendedProvider) {
+        value.ExtendedProvider = { Providers: [], Override: false }
+      }
       const block = await Block.encode({ value, codec: dagJson, hasher: sha256 })
 
       // Upload the file to S3

--- a/test/advertisement.test.js
+++ b/test/advertisement.test.js
@@ -6,7 +6,7 @@ const t = require('tap')
 const varint = require('varint')
 const dagJson = require('@ipld/dag-json')
 const { MockAgent, setGlobalDispatcher } = require('undici')
-const { awsRegion, s3Bucket, indexerNodeUrl } = require('../src/config')
+const { awsRegion, s3Bucket, indexerNodeUrl, bitswapPeerMultiaddr } = require('../src/config')
 const { handler } = require('../src/index')
 const { trackAWSUsages, mockPeerIds } = require('./utils/mock')
 
@@ -290,4 +290,71 @@ t.test('advertisement - handles indexer announcing generic error', async t => {
       }),
     { message: 'ERROR' }
   )
+})
+
+t.test('advertisement - clear extended provider', async t => {
+  t.plan(18)
+
+  const mockAgent = new MockAgent()
+  const mockHeadPool = mockAgent.get(`https://${s3Bucket}.s3.${awsRegion}.amazonaws.com`)
+  const mockIndexerPool = mockAgent.get(indexerNodeUrl)
+  mockPeerIds()
+
+  const head = 'baguqeeralr4pwxvbcc6voioqyc6aneg4pkoh5rhrfj35gbhrpxpeavsh6vsa'
+  mockAgent.disableNetConnect()
+  mockHeadPool
+    .intercept({ method: 'GET', path: '/head' })
+    .reply(200, `{"head": {"/": "${head}"}}`, {
+      headers: { 'content-type': 'application/json' }
+    })
+  mockIndexerPool
+    .intercept({
+      method: 'PUT',
+      path: '/ingest/announce'
+    })
+    .reply(204, '')
+
+  trackAWSUsages(t)
+  setGlobalDispatcher(mockAgent)
+
+  t.strictSame(
+    await handler({
+      Records: [
+        { body: 'ClearExtendedProvider' }
+      ]
+    }),
+    {}
+  )
+
+  t.equal(t.context.s3.puts.length, 2)
+  t.equal(t.context.s3.puts[0].Bucket, s3Bucket)
+  t.ok(t.context.s3.puts[0].Key.startsWith('bagu'))
+  t.equal(t.context.s3.puts[1].Bucket, s3Bucket)
+  t.equal(t.context.s3.puts[1].Key, 'head')
+
+  const ad = dagJson.decode(t.context.s3.puts[0].Body)
+
+  // AC6 chain continuity
+  t.equal(ad.PreviousID.toString(), head)
+
+  // AC3 ExtendedProvider field present with empty Providers array
+  t.ok(ad.ExtendedProvider)
+  t.ok(Array.isArray(ad.ExtendedProvider.Providers))
+  t.equal(ad.ExtendedProvider.Providers.length, 0)
+
+  // AC4 Override field present (value not locked)
+  t.ok('Override' in ad.ExtendedProvider)
+
+  // AC5 base provider unchanged - Addresses
+  t.ok(Array.isArray(ad.Addresses))
+  t.equal(ad.Addresses.length, 1)
+  t.equal(ad.Addresses[0], bitswapPeerMultiaddr)
+
+  // AC5 base provider unchanged - Provider peer ID
+  t.equal(typeof ad.Provider, 'string')
+  t.ok(ad.Provider.length > 0)
+
+  // AC7 signature present
+  t.ok(ad.Signature instanceof Uint8Array || Buffer.isBuffer(ad.Signature))
+  t.ok(ad.Signature.length > 0)
 })


### PR DESCRIPTION
## Summary

Adds a new SQS special-message body `ClearExtendedProvider` to the publishing handler, mirroring the existing `AnnounceHTTP` precedent (#27). When the handler receives a message with this body, it publishes a single advertisement whose `ExtendedProvider.Providers` field is explicitly empty (`[]`). storetheindex ≥ commit [`e1afa6b8`](https://github.com/ipni/storetheindex/commit/e1afa6b853bcd349839e92a4fad2882c1f331829) (from [PR #2814](https://github.com/ipni/storetheindex/pull/2814)) honors this shape via its `registry.Update` `Empty()` branch, setting `info.ExtendedProviders = nil` so subsequent lookups return no ExtendedProvider entries. See [`ipni/storetheindex#1745`](https://github.com/ipni/storetheindex/issues/1745) for the design rationale and @gammazero's recommendation.

The base provider (bitswap) is intentionally left intact on the advertisement — this PR only clears the ExtendedProvider half. Operators wanting to also disable the bitswap routing should handle that out-of-band (e.g. by taking the bitswap peer offline at the network layer; its still-advertised multiaddrs will fail to connect).

## Deliverables

| File | Status | Summary |
|------|--------|---------|
| `src/handlers/advertisement.js` | Modified | New constant + dispatch branch; post-`encodeAndSign` attachment of `ExtendedProvider: { Providers: [], Override: false }` |
| `test/advertisement.test.js` | Modified | New `tap` test `advertisement - clear extended provider` (18 assertions) mirroring the existing `extended provider` test pattern |

## How the empty-Providers attachment works

`@web3-storage/ipni`'s `Advertisement.encodeAndSign()` only writes the `ExtendedProvider` field when `providers.length > 1`. The advertisement's `Signature` is computed over `previous + entries + provider.peerId + provider.addresses + provider.metadata + IsRm` — it does NOT cover the ExtendedProvider list. So we construct a single-provider `Advertisement` (the bitswap base), call `encodeAndSign()`, then attach `value.ExtendedProvider = { Providers: [], Override: false }` to the returned value before encoding to dag-json. The AD signature remains valid because the bytes it covers are unchanged.

## Operator runbook

Trigger:

1. Verify the indexers you care about are running storetheindex ≥ `e1afa6b8` (PR #2814 merged 2026-04-08). Older indexers will ingest the ad cleanly but treat the empty-Providers attachment as a no-op; forward-compatible.
2. Verify publisher-lambda is deployed and its input SQS queue is reachable.
3. Send a single message:
   ```bash
   aws sqs send-message \
     --queue-url <publisher-lambda-input-queue-url> \
     --message-body ClearExtendedProvider
   ```
4. Tail publisher-lambda CloudWatch logs — expect a single advertisement construction + two S3 writes (the new ad object + HEAD update).

Verify:

5. Fetch the new HEAD: `curl https://<bucket>.s3.<region>.amazonaws.com/head` — confirm it points at a new CID.
6. Fetch the new ad: `curl https://<bucket>.s3.<region>.amazonaws.com/<new-cid>` and confirm the JSON contains `"ExtendedProvider": { "Providers": [], "Override": false }`.
7. Wait for the indexer ingest cycle (typically minutes), then query a previously-indexed multihash against the indexer's find endpoint:
   ```bash
   curl https://cid.contact/cid/<known-indexed-cid>
   ```
   Confirm the response no longer contains ExtendedProvider entries for the publisher peer ID.

Out-of-band (if disabling IPFS retrieval entirely): take the bitswap peer offline at the network layer.

## Test plan

- [x] New test `advertisement - clear extended provider` passes (18/18 assertions)
- [x] Existing tap suite passes (32 prior assertions in `test/advertisement.test.js` + the rest of the suite — `npm test` shows all 5 test files green)
- [x] `npm run lint` clean
- [ ] Manual verification against a dev/staging publisher-lambda before triggering against production

🤖 Generated with [Claude Code](https://claude.com/claude-code)
